### PR TITLE
Allow mounting shares with the same name from different servers

### DIFF
--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -25,7 +25,7 @@ define nfs::client::mount (
 
     nfs::mkdir{ $_nfs4_mount: }
 
-    mount {"shared ${share} by ${::clientcert} on ${_nfs4_mount}":
+    mount {"shared ${server}:${share} by $::clientcert on ${_nfs4_mount}":
       ensure   => $ensure,
       device   => "${server}:/${share}",
       fstype   => 'nfs4',
@@ -63,7 +63,7 @@ define nfs::client::mount (
       perm  => $perm,
     }
 
-    mount {"shared ${share} by ${::clientcert}":
+    mount {"shared ${server}:${share} by $::clientcert on ${_mount}":
       ensure   => $ensure,
       device   => "${server}:${share}",
       fstype   => 'nfs',


### PR DESCRIPTION
Because of how the mount resource name is built the share name has to be unique, meaning that one cannot mount two shares with the same name but exported by two different servers. For non-NFSv4 mounts, it is also not possible to mount the same share on two different mount points.

This (trivial) pull request fixes the problem by changing the resource name to include the server name and adding the mount point name to non-NFSv4 mounts.