### PR TITLE
Add Scientific Linux CERN to the list of supported platforms

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,10 +6,10 @@ class nfs::params (
   $nfs_v4_idmap_domain        = $::domain
 ) {
 
-  # Somehow the ::osfamliy fact doesnt exist on some oled systems
+  # Somehow the ::osfamliy fact doesnt exist on some old systems
 
   case $::operatingsystem {
-    'centos', 'redhat', 'scientific', 'fedora' : { $osfamily = 'redhat' }
+    'centos', 'redhat', 'scientific', 'SLC', 'fedora' : { $osfamily = 'redhat' }
     'debian', 'Ubuntu' : { $osfamily = 'debian' }
     'windows'          : { fail('fail!11') }
     'darwin'           : { $osfamily = 'darwin' }


### PR DESCRIPTION
This pull requests makes the nfs module work on Scientific Linux CERN.
Facter support for Scientific Linux CERN on $::operatingsystem was added at https://github.com/puppetlabs/facter/pull/39.