### PR TITLE
Handle enabling service on RHEL7 and above

### DIFF
--- a/manifests/server/redhat/service.pp
+++ b/manifests/server/redhat/service.pp
@@ -1,7 +1,12 @@
 class nfs::server::redhat::service {
+  if $operatingsystemmajrelease >= 7 {
+    $service_name = "nfs-server"
+  } else {
+    $service_name = "nfs"
+  }
 
   if $nfs::server::redhat::nfs_v4 == true {
-    service {'nfs':
+    service {$service_name:
       ensure     => running,
       enable     => true,
       hasrestart => true,
@@ -10,7 +15,7 @@ class nfs::server::redhat::service {
       subscribe  => [ Concat['/etc/exports'], Augeas['/etc/idmapd.conf'] ],
     }
   } else {
-    service {'nfs':
+    service {$service_name:
       ensure     => running,
       enable     => true,
       hasrestart => true,

--- a/spec/classes/server_redhat_spec.rb
+++ b/spec/classes/server_redhat_spec.rb
@@ -1,17 +1,21 @@
 require 'spec_helper'
 describe 'nfs::server::redhat' do
-  let(:facts) { {:operatingsystemrelease => 6.4 } }
-
+  let(:facts) { {:osmajor => 6 } }
+  it do
+    should contain_class('nfs::client::redhat')
+    should contain_service('nfs').with( 'ensure' => 'running'  )
+  end
+  
+  let(:facts) { {:osmajor => 7 } }
   it do
     should contain_class('nfs::client::redhat')
     should contain_service('nfs-server').with( 'ensure' => 'running'  )
   end
+  
   context ":nfs_v4 => true" do
     let(:params) {{ :nfs_v4 => true , :nfs_v4_idmap_domain => 'teststring' }}
     it do
       should contain_augeas('/etc/idmapd.conf').with_changes(/set Domain teststring/)
     end
-
   end
 end
-


### PR DESCRIPTION
The nfs service name has changed on RHEL7 (and derivatives) from **nfs** to **nfs-server**. 
Therefore the module does not handle correctly enabling the service.
```
Error: Could not enable nfs: 
Error: /Stage[main]/Nfs::Server::Redhat::Service/Service[nfs]/enable: change from false to true failed: Could not enable nfs: 
Notice: /Stage[main]/Nfs::Server::Redhat::Service/Service[nfs]: Triggered 'refresh' from 1 events
```

The following patch should fix this issue.