### PR TITLE
Changes to mount name param defined by server export class to remove spaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
+gem 'rspec', '< 3.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+puppetversion = ENV.key?('PUPPET_GEM_VERSION') ? "#{ENV['PUPPET_GEM_VERSION']}" : ['>= 3.3']
+facterversion = ENV.key?('FACTER_GEM_VERSION') ? "#{ENV['FACTER_GEM_VERSION']}" : ['>= 1.7']
 gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
-gem 'facter', '>= 1.7.0'
+gem 'facter', facterversion
 gem 'rspec', '< 3.2.0'

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -50,9 +50,15 @@ define nfs::server::export (
         clients => $clients,
     }
 
+    if $mount == undef {
+      $_mount = $v3_export_name
+    } else {
+      $_mount = $mount
+    }
+
     @@nfs::client::mount {"shared ${v3_export_name} by ${::clientcert}":
       ensure   => $ensure,
-      mount    => $mount,
+      mount    => $_mount,
       remounts => $remounts,
       atboot   => $atboot,
       options  => $options,

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe 'nfs::client::mount', :type => :define do
-  let(:title) { '/srv/test' }
+  let(:title) { 'shared /srv/test by nfs.int.net' }
   let(:facts) { { :operatingsystem => 'ubuntu' } }
   let(:params) {{ :server => 'nfs.int.net', :share => '/srv/share' } }
   it do
     should compile
     should contain_class('nfs::client')
-    should contain_mount('shared /srv/test by nfs.int.net')
   end
 end

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -1,11 +1,27 @@
 require 'spec_helper'
 
 describe 'nfs::client::mount', :type => :define do
-  let(:title) { 'shared /srv/test by nfs.int.net' }
-  let(:facts) { { :operatingsystem => 'ubuntu' } }
-  let(:params) {{ :server => 'nfs.int.net', :share => '/srv/share' } }
-  it do
-    should compile
-    should contain_class('nfs::client')
+  context "Mount created by exported resource" do
+    let(:title) { 'shared /srv/test by nfs.int.net' }
+    let(:facts) { { :operatingsystem => 'ubuntu' } }
+    let(:params) {{ 
+      :server => 'nfs.int.net',
+      :share  => '/srv/share',
+      :mount  => Undef.new
+    }}
+    it do
+      should compile
+      should contain_class('nfs::client')
+    end
+  end
+
+  context "Mount manually set" do
+    let(:title) { '/srv/test' }
+    let(:facts) { { :operatingsystem => 'ubuntu' } }
+    let(:params) {{ :server => 'nfs.int.net', :share => '/srv/share' } }
+    it do
+      should compile
+      should contain_class('nfs::client')
+    end
   end
 end

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -5,6 +5,8 @@ describe 'nfs::client::mount', :type => :define do
   let(:facts) { { :operatingsystem => 'ubuntu' } }
   let(:params) {{ :server => 'nfs.int.net', :share => '/srv/share' } }
   it do
+    should compile
     should contain_class('nfs::client')
+    should contain_mount('shared /srv/test by nfs.int.net')
   end
 end

--- a/spec/defines/client_spec.rb
+++ b/spec/defines/client_spec.rb
@@ -3,25 +3,28 @@ require 'spec_helper'
 describe 'nfs::client::mount', :type => :define do
   context "Mount created by exported resource" do
     let(:title) { 'shared /srv/test by nfs.int.net' }
-    let(:facts) { { :operatingsystem => 'ubuntu' } }
+    let(:facts) { { :operatingsystem => 'ubuntu', :clientcert => 'test.example.com' } }
     let(:params) {{ 
       :server => 'nfs.int.net',
       :share  => '/srv/share',
-      :mount  => Undef.new
+      :mount  => '/srv/share'
     }}
     it do
       should compile
       should contain_class('nfs::client')
+      should contain_mount('shared nfs.int.net:/srv/share by test.example.com /srv/share')
     end
   end
 
   context "Mount manually set" do
     let(:title) { '/srv/test' }
-    let(:facts) { { :operatingsystem => 'ubuntu' } }
+    let(:facts) { { :operatingsystem => 'ubuntu', :clientcert => 'test.example.com' } }
     let(:params) {{ :server => 'nfs.int.net', :share => '/srv/share' } }
     it do
       should compile
       should contain_class('nfs::client')
+      should contain_mount('shared nfs.int.net:/srv/share by test.example.com /srv/test')
+      #should contain_mount('/srv/test')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,7 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+class Undef
+  def inspect
+    'undef'
+  end
+end 


### PR DESCRIPTION
This pull request contains several fixes:
* Fixing version of rspec used to work on ruby 1.8.7 so all travis runs work properly
* Fixed usage of the PUPPET_GEM_VERSION and FACTER_GEM_VERSION env vars so travis builds actually use the dependancy versions they say they are
* Fixed bug in naming of `mount()` type when not defining `mount` param on exports.

**More info about mount bug:**
Currently when defining nfs3 mounts using `nfs::server::export` but not declaring the `mount` param it defaults to `undef` however because the `nfs::client::mount` defaults its `mount` param to the resources title the `undef` is ignored. This then results in the `name` param passed to the `mount()` type containing spaces (i.e. "shared /srv/test by nfs.int.net"). When running Puppet on the client you will get an error similar to the following on Puppet >= 3.3:

```
error during compilation: Parameter name failed on Mount[shared nfs.int.net:/srv/share by mylocal.example.com shared /srv/test by nfs.int.net]: name must not contain whitespace...
```

So to solve this setting `mount` to the `export_name` to ensure it is always set.

See Travis build: https://travis-ci.org/sedan07/puppet-nfs/builds/55987020 for proof of bug. Note: Puppet < 3.3 will allow spaces in mount name (but fails on dir creation) but Puppet >= 3.3 throws validation error.