### PR TITLE
mkdir: revert default permissions from 0777 to 0755 (Resolves #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,15 +486,18 @@ Default is undef. Used to identify a catalog item for filtering by storeconfigs 
 
 #####`owner` (optional)
 
-Default is 'root'. Sets owner of local mountpoint.
+Default is 'root'. Sets owner of mountpoint directory. This is applied to the directory on every run, which means it is used both on the base mountpoint creation when unmounted, and also once mounted on the target NFS server and thus all servers accessing the same share.
+
 
 #####`group` (optional)
 
-Default is `root`. Sets goup ownership of mountpoint.
+Default is `root`. Sets group of mountpoint directory. This is applied to the directory on every run, which means it is used both on the base mountpoint creation when unmounted, and also once mounted on the target NFS server and thus all servers accessing the same share.
+
 
 #####`perm` (optional)
 
-Default is '0777'. Set mode of mountpoint.
+Default is '0755'. Sets mode of mountpoint directory. This has changed from previous versons which used '0777' (world writable). This is applied to the directory on every run, which means it is used both on the base mountpoint creation when unmounted, and also once mounted on the target NFS server and thus all servers accessing the same share.
+
 
 ##Requirements
 

--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -10,7 +10,7 @@ define nfs::client::mount (
   $nfstag    = undef,
   $owner     = 'root',
   $group     = 'root',
-  $perm      = '0777',
+  $perm      = '0755',
 ) {
 
   include ::nfs::client

--- a/manifests/mkdir.pp
+++ b/manifests/mkdir.pp
@@ -2,7 +2,7 @@
 define nfs::mkdir (
   $owner = 'root',
   $group = 'root',
-  $perm  = '0777'
+  $perm  = '0755'
 ) {
   exec { "mkdir_recurse_${name}":
     path    => ['/bin', '/usr/bin'],


### PR DESCRIPTION
It is not desirable to create a mountpoint as world writable by default, as if
the filesystem is not mounted any user can write data that may be inadvertently
used by another service and security context.

Additionally, the directory assumes permissions from the NFS server once mounted
which will then be modified by this resource to make the entire NFS share world
writable on all servers.

This option is configurable and any user requiring this behavior can override
the default.

Partial revert of 968117be0926164c57eda5653b9bf2f7e1c8f5b3 (added gentoo compatibility)