### PR TITLE
Fixed problems with a host being client & server

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -41,9 +41,11 @@ class nfs::client (
   Class["::nfs::client::${::nfs::params::osfamily}::service"] ->
   Class['::nfs::client']
 
-  class{ "nfs::client::${::nfs::params::osfamily}":
-    nfs_v4              => $nfs_v4,
-    nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+  if !defined( Class["nfs::client::${::nfs::params::osfamily}"]) {
+    class{ "nfs::client::${::nfs::params::osfamily}":
+      nfs_v4              => $nfs_v4,
+      nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+    }
   }
 
 }

--- a/manifests/server/debian.pp
+++ b/manifests/server/debian.pp
@@ -4,9 +4,11 @@ class nfs::server::debian(
   $nfs_v4_idmap_domain = undef
 ) {
 
-  class{ 'nfs::client::debian':
-    nfs_v4              => $nfs_v4,
-    nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+  if !defined(Class['nfs::client::debian']) {
+    class{ 'nfs::client::debian':
+      nfs_v4              => $nfs_v4,
+      nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+    }
   }
 
   include nfs::server::debian::install, nfs::server::debian::service

--- a/manifests/server/gentoo.pp
+++ b/manifests/server/gentoo.pp
@@ -4,9 +4,11 @@ class nfs::server::gentoo(
   $nfs_v4_idmap_domain = undef
 ) {
 
-  class{ 'nfs::client::gentoo':
-    nfs_v4              => $nfs_v4,
-    nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+  if !defined(Class['nfs::client::gentoo']) {
+    class{ 'nfs::client::gentoo':
+      nfs_v4              => $nfs_v4,
+      nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+    }
   }
 
   include nfs::server::gentoo::install, nfs::server::gentoo::service

--- a/manifests/server/redhat.pp
+++ b/manifests/server/redhat.pp
@@ -3,9 +3,11 @@ class nfs::server::redhat(
   $nfs_v4_idmap_domain = undef
 ) {
 
-  class{ 'nfs::client::redhat':
-    nfs_v4              => $nfs_v4,
-    nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+  if !defined(Class['nfs::client::redhat']) {
+    class{ 'nfs::client::redhat':
+      nfs_v4              => $nfs_v4,
+      nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
+    }
   }
 
   include nfs::server::redhat::install, nfs::server::redhat::service


### PR DESCRIPTION
Both exporting and mounting an nfs share utilizes the ::nfs::client::<osfamily..> class, causing a duplicate resource errors when compiling catalogs in puppet. This now checks whether that class is already defined before trying to define it again.