### PR TITLE
Update configure.pp

### DIFF
--- a/manifests/server/configure.pp
+++ b/manifests/server/configure.pp
@@ -2,7 +2,7 @@ class nfs::server::configure {
 
   concat {'/etc/exports':
     ensure  => present,
-    require => Class["nfs::server::${::nfs::server::params::osfamily}"],
+    require => Class["nfs::server::${::nfs::params::osfamily}"],
   }
 
 


### PR DESCRIPTION
${::nfs::server::params::osfamily}  does not exist and is a mistake, corrected to ${::nfs::params::osfamily}
This fixes the warning thrown and ensures the require will definitely work properly.