### PR TITLE
make the name/ip of the server a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,9 @@ Default is undef. Used to identify a catalog item for filtering by storeconfigs 
 
 Default is 'localhost(ro)'. Copied directly into /etc/exports as a string, for simplicity.
 
+#####`server` (optional)
+
+Default is `$::clientcert`. Used to specify a other ip/name for the client to connect to. Usefull in machines with multiple ip addresses or network interfaces
 #####Example
 
 ```puppet

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -11,7 +11,8 @@ define nfs::server::export (
   $atboot         = false,
   $options        = '_netdev',
   $bindmount      = undef,
-  $nfstag         = undef
+  $nfstag         = undef,
+  $server         = $::clientcert
 ) {
 
 
@@ -39,7 +40,7 @@ define nfs::server::export (
       bindmount => $bindmount,
       nfstag    => $nfstag,
       share     => $v4_export_name,
-      server    => $::clientcert,
+      server    => $server,
     }
 
     } else {
@@ -64,7 +65,7 @@ define nfs::server::export (
       options  => $options,
       nfstag   => $nfstag,
       share    => $v3_export_name,
-      server   => $::clientcert,
+      server   => $server,
     }
   }
 }


### PR DESCRIPTION
i needed this to create a separate storage lan where the $::clientcert was not resolving to the ip on the storage lan