### PR TITLE
Default mount name should be undef so it gets filled in the module

### DIFF
--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -2,7 +2,7 @@ define nfs::client::mount (
   $server,
   $share,
   $ensure    = 'mounted',
-  $mount     = $title,
+  $mount     = undef,
   $remounts  = false,
   $atboot    = false,
   $options   = '_netdev',


### PR DESCRIPTION
Otherwise it tries to mount the share by its title unless you have explicitly specified the path in the node manifest. And if you have, autogeneration of mount paths ("${nfs::client::nfs_v4_mount_root}/${share}") won't work.