### PR TITLE
More flexible nfsv4 export naming.

### DIFF
--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -1,6 +1,7 @@
 define nfs::server::export (
   $v3_export_name = $name,
-  $v4_export_name = regsubst($name, '.*/(.*)', '\1' ),
+  # Grab the final directory name in the given path and make it our default nfsv4 export name.
+  $v4_export_name = regsubst($name, '.*/([^/]+)/?$', '\1' ),
   $clients        = 'localhost(ro)',
   $bind           = 'rbind',
   # globals for this share


### PR DESCRIPTION
When exporting a directory using nfsv4, if your directory name had a trailing slash the export would fail in a difficult to understand manner. I've updated the nfsv4 export name regex to be more friendly about trailing slashes, which eliminates the problem.