### PR TITLE
Fix "Could not install 'puppetlabs-concat' (v2.0.1)"

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "issues_url": "https://github.com/echocat/puppet-nfs/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1"},
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <2.0.0"},
     {"name":"herculesteam/augeasproviders_shellvar","version_requirement":">= 2.1.0"}
   ]
 }


### PR DESCRIPTION
puppetlabs-concat 2.x is deleted on forge.