### PR TITLE
Issue #30 Add ability to set owner,group,perms on server::export

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ and on individual nodes.
     }
   }
 ```
+Set ownership and permissions on the folder being exported
+
+```puppet
+  node server {
+    nfs::server::export{ '/data_folder':
+      ensure  => 'mounted',
+      clients => '10.0.0.0/24(rw,insecure,no_subtree_check,async,no_root_squash) localhost(rw)',
+      owner => 'root',
+      group => 'root',
+      perms => '0755',
+    }
+  }
+```
 
 By default, mounts are mounted in the same folder on the clients as
 they were exported from on the server

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -1,9 +1,12 @@
 define nfs::server::export (
   $v3_export_name = $name,
   # Grab the final directory name in the given path and make it our default nfsv4 export name.
-  $v4_export_name = regsubst($name, '.*/([^/]+)/?$', '\1' ),
+  $v4_export_name = regsubst($name, '.*/([^/]+)/?$', '\1'),
   $clients        = 'localhost(ro)',
   $bind           = 'rbind',
+  $owner          = 'root',
+  $group          = 'root',
+  $perms          = '0755',
   # globals for this share
   # propogated to storeconfigs
   $ensure         = 'mounted',
@@ -13,26 +16,24 @@ define nfs::server::export (
   $options        = '_netdev',
   $bindmount      = undef,
   $nfstag         = undef,
-  $server         = $::clientcert
-) {
-
-
+  $server         = $::clientcert) {
   if $nfs::server::nfs_v4 {
-
     nfs::server::export::nfs_v4::bindmount { $name:
       ensure         => $ensure,
       v4_export_name => $v4_export_name,
       bind           => $bind,
+      owner          => $owner,
+      group          => $group,
+      perms          => $perms,
     }
 
-    nfs::server::export::configure{
-      "${nfs::server::nfs_v4_export_root}/${v4_export_name}":
-        ensure  => $ensure,
-        clients => $clients,
-        require => Nfs::Server::Export::Nfs_v4::Bindmount[$name]
+    nfs::server::export::configure { "${nfs::server::nfs_v4_export_root}/${v4_export_name}":
+      ensure  => $ensure,
+      clients => $clients,
+      require => Nfs::Server::Export::Nfs_v4::Bindmount[$name]
     }
 
-    @@nfs::client::mount {"shared ${v4_export_name} by ${::clientcert}":
+    @@nfs::client::mount { "shared ${v4_export_name} by ${::clientcert}":
       ensure    => $ensure,
       mount     => $mount,
       remounts  => $remounts,
@@ -44,12 +45,10 @@ define nfs::server::export (
       server    => $server,
     }
 
-    } else {
-
-    nfs::server::export::configure{
-      $v3_export_name:
-        ensure  => $ensure,
-        clients => $clients,
+  } else {
+    nfs::server::export::configure { $v3_export_name:
+      ensure  => $ensure,
+      clients => $clients,
     }
 
     if $mount == undef {
@@ -58,7 +57,7 @@ define nfs::server::export (
       $_mount = $mount
     }
 
-    @@nfs::client::mount {"shared ${v3_export_name} by ${::clientcert}":
+    @@nfs::client::mount { "shared ${v3_export_name} by ${::clientcert}":
       ensure   => $ensure,
       mount    => $_mount,
       remounts => $remounts,

--- a/manifests/server/export/nfs_v4/bindmount.pp
+++ b/manifests/server/export/nfs_v4/bindmount.pp
@@ -2,20 +2,24 @@ define nfs::server::export::nfs_v4::bindmount (
   $v4_export_name,
   $bind,
   $ensure = 'mounted',
-) {
-
+  $owner  = 'root',
+  $group  = 'root',
+  $perms  = '0755') {
   $expdir = "${nfs::server::nfs_v4_export_root}/${v4_export_name}"
 
-  nfs::mkdir{ $expdir: }
+  nfs::mkdir { $expdir:
+    owner => $owner,
+    group => $group,
+    perm  => $perms
+  }
 
-  mount {
-    $expdir:
-      ensure  => $ensure,
-      device  => $name,
-      atboot  => true,
-      fstype  => 'none',
-      options => $bind,
-      require => Nfs::Mkdir[$expdir],
+  mount { $expdir:
+    ensure  => $ensure,
+    device  => $name,
+    atboot  => true,
+    fstype  => 'none',
+    options => $bind,
+    require => Nfs::Mkdir[$expdir],
   }
 
 }


### PR DESCRIPTION
When using the nfs::server::export resource it creates a bindmount resource,
which in turn creates a nfs::mkdir resource. Adding these parameters and
passing them through provides the ability to set owner, group and mode
metaparams on the file resource within nfs::mkdir from a server::export resource.