### PR TITLE
Add basic hiera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,11 @@ Export root, where we bind mount shares, default /export
 Domain setting for idmapd, must be the same across server
 and clients. Default is to use $domain fact.
 
+#####`hiera_exports` (optional)
+
+If set, the hiera variable nfs::server::exports will be used to
+construct nfs::server::export resources
+
 #####Examples
 
 ```puppet

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -43,7 +43,9 @@ class nfs::server (
   $nfs_v4_root_export_tag       = undef,
   #
   $mountd_port                   = undef,
-  $mountd_threads                = 1
+  $mountd_threads                = 1,
+  #
+  $hiera_exports                = false
 ) inherits nfs::params {
 
   class { "nfs::server::${::nfs::params::osfamily}":
@@ -54,5 +56,10 @@ class nfs::server (
   }
 
   include nfs::server::configure
+
+  if $hiera_exports {
+    $exports = hiera_hash('nfs::server::exports')
+    create_resources(nfs::server::export, $exports)
+  }
 
 }


### PR DESCRIPTION
With this, you can configure your exports entirely through hiera, e.g.
```
nfs::server::hiera_exports: true
nfs::server::exports:
  /mnt/something:
    ensure: mounted
    clients: '*(fsid=0,ro,insecure,async,all_squash,no_subtree_check,mountpoint=/mnt/something)'
```