### PR TITLE
Remove unneeded call to hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,13 +347,13 @@ Export root, where we bind mount shares, default /export
 Domain setting for idmapd, must be the same across server
 and clients. Default is to use $domain fact.
 
-#####`hiera_exports` (optional)
+#####`exports` (optional)
 
-If set, the hiera variable nfs::server::exports will be used to
-construct nfs::server::export resources
+If set, this attribute will be used to
+construct nfs::server::export resources. You can use you ENC or hiera to
+provide the hash of nfs::server::export resources definitions:
 
 ```hiera
-nfs::server::hiera_exports: true
 nfs::server::exports:
   /mnt/something:
     ensure: mounted

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,7 +45,7 @@ class nfs::server (
   $mountd_port                   = undef,
   $mountd_threads                = 1,
   #
-  $hiera_exports                = false
+  $exports                      = undef,
 ) inherits nfs::params {
 
   class { "nfs::server::${::nfs::params::osfamily}":
@@ -57,8 +57,7 @@ class nfs::server (
 
   include nfs::server::configure
 
-  if $hiera_exports {
-    $exports = hiera_hash('nfs::server::exports')
+  if $exports {
     create_resources(nfs::server::export, $exports)
   }
 


### PR DESCRIPTION
Explicit hiera call is not needed and should not be made inside modules.

This pull request still allows the behaviour described in the README
file.