### PR TITLE
Supporting kernel 4.x in recent Amazon Linux releases

### DIFF
--- a/manifests/client/redhat/params.pp
+++ b/manifests/client/redhat/params.pp
@@ -18,7 +18,7 @@ class nfs::client::redhat::params {
       $osmajor = 7
     }
     # Amazon linux operatingsystemrelease is verbose: 3.10.35-43.137.amzn1.x86_64
-    /^3\.(\d|-|\.)+(amzn){1}/: {
+    /^[34]\.(\d|-|\.)+(amzn){1}/: {
       $osmajor = 6
     }
     default:{
@@ -26,5 +26,3 @@ class nfs::client::redhat::params {
     }
   }
 }
-
-

--- a/spec/classes/client_redhat_spec.rb
+++ b/spec/classes/client_redhat_spec.rb
@@ -62,6 +62,28 @@ describe 'nfs::client::redhat' do
     end
   end
 
+  context "operatingsystemrelease => 4.1.7-15.23.amzn1.x86_64" do
+    let(:facts) { {:operatingsystemrelease => "4.1.7-15.23.amzn1.x86_64" } }
+    it do
+      should contain_class('nfs::client::redhat::install')
+      should contain_class('nfs::client::redhat::configure')
+      should contain_class('nfs::client::redhat::service')
+
+      should contain_service('nfslock').with(
+        'ensure' => 'running'
+      )
+      should contain_service('netfs').with(
+        'enable' => 'true'
+      )
+      should contain_package('nfs-utils')
+      should contain_class('nfs::client::redhat')
+      should contain_package('rpcbind')
+      should contain_service('rpcbind').with(
+        'ensure' => 'running'
+      )
+    end
+  end
+
   context ":nfs_v4 => true" do
     let(:params) {{ :nfs_v4 => true }}
     let(:facts) {{ :operatingsystemrelease => '6.4' }}

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -41,6 +41,10 @@ describe 'nfs::client' do
     let(:facts) { {:operatingsystem => 'Amazon', :operatingsystemrelease =>  '3.10.35-43.137.amzn1.x86_64' } }
     it { should contain_class('nfs::client::redhat') }
   end
+  context "operatingsysten => Amazon v4" do
+    let(:facts) { {:operatingsystem => 'Amazon', :operatingsystemrelease =>  '4.1.7-15.23.amzn1.x86_64' } }
+    it { should contain_class('nfs::client::redhat') }
+  end
   context "operatingsysten => gentoo" do
     let(:facts) { {:operatingsystem => 'gentoo', } }
     it { should contain_class('nfs::client::gentoo') }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -17,21 +17,21 @@ describe 'nfs::server' do
     let(:facts) { {:operatingsystem => 'ubuntu', :concat_basedir => '/tmp', } }
     it { should contain_class('nfs::server::ubuntu') }
   end
-  
+
   context "operatingsysten => ubuntu with params for mountd" do
     let(:facts) { {:operatingsystem => 'ubuntu', :concat_basedir => '/tmp', } }
     let(:params) {{ :mountd_port => '4711', :mountd_threads => '99' }}
-    
-    it do 
+
+    it do
      should contain_class('nfs::server::ubuntu').with( 'mountd_port' => '4711', 'mountd_threads' => '99' )
     end
   end
-  
+
   context "operatingsysten => debian" do
     let(:facts) { {:operatingsystem => 'debian', :concat_basedir => '/tmp',} }
     it { should contain_class('nfs::server::debian') }
   end
-  
+
   context "operatingsysten => scientific" do
     let(:facts) { {:operatingsystem => 'scientific', :concat_basedir => '/tmp', :operatingsystemrelease => '6.4' } }
     it { should contain_class('nfs::server::redhat') }
@@ -40,7 +40,7 @@ describe 'nfs::server' do
     let(:facts) { {:operatingsystem => 'SLC', :concat_basedir => '/tmp', :operatingsystemrelease => '6.4' } }
     it { should contain_class('nfs::server::redhat') }
   end
-  
+
   context "operatingsysten => centos v6" do
     let(:facts) { {:operatingsystem => 'centos', :concat_basedir => '/tmp', :operatingsystemrelease => '6.4' } }
     it { should contain_class('nfs::server::redhat') }
@@ -51,6 +51,10 @@ describe 'nfs::server' do
   end
   context "operatingsysten => Amazon v3" do
     let(:facts) { {:operatingsystem => 'Amazon', :concat_basedir => '/tmp', :operatingsystemrelease => '3.10.35-43.137.amzn1.x86_64' } }
+    it { should contain_class('nfs::server::redhat') }
+  end
+  context "operatingsysten => Amazon v3" do
+    let(:facts) { {:operatingsystem => 'Amazon', :concat_basedir => '/tmp', :operatingsystemrelease => '4.1.7-15.23.amzn1.x86_64' } }
     it { should contain_class('nfs::server::redhat') }
   end
   context "operatingsysten => gentoo" do


### PR DESCRIPTION
Recent Amazon Linux releases are shipping with kernel 4.x. Extending the work done in #17 to add support for these.

(re-issue of #47)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>