### PR TITLE
Enable idmapd service on Ubuntu when NFSv4 configured; disable when not.

### DIFF
--- a/manifests/client/ubuntu/service.pp
+++ b/manifests/client/ubuntu/service.pp
@@ -9,9 +9,13 @@ class nfs::client::ubuntu::service {
   if $nfs::client::ubuntu::nfs_v4 {
     service { 'idmapd':
       ensure    => running,
+      enable    => true,
       subscribe => Augeas['/etc/idmapd.conf', '/etc/default/nfs-common'],
     }
   } else {
-    service { 'idmapd': ensure => stopped, }
+    service { 'idmapd':
+      ensure => stopped,
+      enable => false,
+    }
   }
 }


### PR DESCRIPTION
In the case of $nfs::client::ubuntu::nfs_v4 = false, Puppet would stop the idmapd service but when the host is rebooted, the service will start again as it wasn't disabled. The inverse is also true for $nfs::client::ubuntu::nfs_v4 = true. This caused puppet to make a change on the first run after every reboot. Adding the enable parameter to the service resources should fix this.