### PR TITLE
Enable idmapd service resource on Debian when NFSv4 configured

### DIFF
--- a/manifests/client/debian/service.pp
+++ b/manifests/client/debian/service.pp
@@ -9,6 +9,7 @@ class nfs::client::debian::service {
   if $nfs::client::debian::nfs_v4 {
     service { 'idmapd':
       ensure    => running,
+      enable    => true,
       name      => 'nfs-common',
       subscribe => Augeas['/etc/idmapd.conf', '/etc/default/nfs-common'],
     }


### PR DESCRIPTION
Similar change to the service resource that was done for Ubuntu. Make sure the service is enabled so that it comes up on boot.