### PR TITLE
Fixed bug for Issue #50.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Gemfile.lock
 # others
 *swp
 .DS_Store
+
+vagrant/puppet/modules/*
+vagrant/puppet/logs/*

--- a/manifests/client/ubuntu/service.pp
+++ b/manifests/client/ubuntu/service.pp
@@ -4,18 +4,26 @@ class nfs::client::ubuntu::service {
     ensure    => running,
     enable    => true,
     hasstatus => false,
+    provider  => 'init',
   }
 
-  if $nfs::client::ubuntu::nfs_v4 {
-    service { 'idmapd':
-      ensure    => running,
-      enable    => true,
-      subscribe => Augeas['/etc/idmapd.conf', '/etc/default/nfs-common'],
+  # From Ubuntu 15.04 and onwards, the idmapd service does NOT have an init
+  # script, as its apart of the nfs-server service.
+  case $::lsbdistrelease {
+    '10.04','12.04','14.04': {
+      if $nfs::client::ubuntu::nfs_v4 {
+        service { 'idmapd':
+          ensure    => running,
+          enable    => true,
+          subscribe => Augeas['/etc/idmapd.conf', '/etc/default/nfs-common'],
+        }
+      } else {
+        service { 'idmapd':
+          ensure => stopped,
+          enable => false,
+        }
+      }
     }
-  } else {
-    service { 'idmapd':
-      ensure => stopped,
-      enable => false,
-    }
+    default: { }
   }
 }

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#require './config.lucid.rb'
+#require './config.precise.rb'
+#require './config.trusty.rb'
+require './config.vivid.rb'
+include MyVars
+
+Vagrant.configure("2") do |config|
+
+  # set the boxes dynamically
+  config.vm.box     = OS
+  config.vm.box_url = OS_URL
+  
+  # system memory
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+  end
+
+  # default ip address
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # setup puppet
+  config.vm.provision :shell, :path => "scripts/upgrade-puppet.sh"
+
+  # puppet configuration
+  config.vm.provision "puppet" do |puppet|
+    puppet.module_path    = ["puppet/modules/","../../"]
+    puppet.manifests_path = "../tests"
+    puppet.manifest_file  = "init.pp"
+  end
+end

--- a/vagrant/config.lucid.rb
+++ b/vagrant/config.lucid.rb
@@ -1,0 +1,4 @@
+module MyVars
+  OS     = "ubuntu10"
+  OS_URL = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box"
+end

--- a/vagrant/config.precise.rb
+++ b/vagrant/config.precise.rb
@@ -1,0 +1,4 @@
+module MyVars
+  OS     = "ubuntu/precise64"
+  OS_URL = "https://atlas.hashicorp.com/ubuntu/boxes/precise64"
+end

--- a/vagrant/config.trusty.rb
+++ b/vagrant/config.trusty.rb
@@ -1,0 +1,4 @@
+module MyVars
+  OS     = "ubuntu/trusty64"
+  OS_URL = "https://atlas.hashicorp.com/ubuntu/boxes/trusty64"
+end

--- a/vagrant/config.vivid.rb
+++ b/vagrant/config.vivid.rb
@@ -1,0 +1,4 @@
+module MyVars
+  OS     = "ubuntu/vivid64"
+  OS_URL = "https://atlas.hashicorp.com/ubuntu/boxes/vivid64"
+end

--- a/vagrant/provision.bash
+++ b/vagrant/provision.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+ 
+mkdir -p puppet/modules
+PUPPETFILE=puppet/Puppetfile PUPPETFILE_DIR=puppet/modules r10k --verbose 3 puppetfile install
+
+vagrant provision 
+
+if [ $? -eq 0 ] ; then
+    echo "*** Manifest deployed without errors ***"
+    exit 0
+else
+    echo "*** Manifest has ERRORs.  See puppet/log/puppet.log for details ***" >&2
+    exit 1
+fi

--- a/vagrant/puppet/Puppetfile
+++ b/vagrant/puppet/Puppetfile
@@ -1,0 +1,4 @@
+# puppet forge modules
+mod 'puppetlabs/stdlib'                     , '4.9.0'
+mod 'puppetlabs/concat'                     , '1.2.4'
+mod 'herculesteam/augeasproviders_shellvar' , '2.2.1'

--- a/vagrant/readme.md
+++ b/vagrant/readme.md
@@ -1,0 +1,30 @@
+# Testing
+
+## About
+This directory contains vagrant code for testing this module.  This utilizes R10K + Puppet in order to pull all of the necessary dependancies.  It uses the main test class (tests/init.pp) for testing.
+
+## Operating Systems
+The vagrant configuration file specifies the OS used by the vagrant provider (such as virtual box).  The only listed OS's as of now are Ubuntu but additional can be added if this testing environment is to be extended.
+
+### Selecting an OS
+* Edit the Vagrantfile
+* Comment out the OS you don't want
+* Uncomment the OS you want to test
+
+See below:
+
+```
+require './config.lucid.rb'
+#require './config.precise.rb'
+#require './config.trusty.rb'
+#require './config.vivid.rb'
+```
+
+## Test
+To test a single configuration do the following:
+
+```
+vagrant destroy
+./run.bash
+```
+This will ensure that any previous test runs are destroyed before starting a new one.  See the output.  The last line should indicate if the test passed or failed.

--- a/vagrant/run.bash
+++ b/vagrant/run.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+ 
+if [ -f puppet/logs/puppet.log ] ; then
+    rm puppet/logs/puppet.log
+fi
+
+mkdir -p puppet/modules
+PUPPETFILE=puppet/Puppetfile PUPPETFILE_DIR=puppet/modules r10k --verbose 3 puppetfile install
+
+vagrant up --provision
+
+if [ $? -eq 0 ] ; then
+    echo "*** Manifest deployed without errors ***"
+    exit 0
+else
+    echo "*** Manifest has ERRORs.  See puppet/log/puppet.log for details ***" >&2
+    exit 1
+fi

--- a/vagrant/scripts/upgrade-puppet.sh
+++ b/vagrant/scripts/upgrade-puppet.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+DISTRIB_CODENAME=$(lsb_release --codename --short)
+DEB="puppetlabs-release-${DISTRIB_CODENAME}.deb"
+DEB_PROVIDES="/etc/apt/sources.list.d/puppetlabs.list" # Assume that this file's existence means we have the Puppet Labs repo added
+
+if [ ! -e $DEB_PROVIDES ]
+then
+    apt-get install --yes lsb-release
+    # Print statement useful for debugging, but automated runs of this will interpret any output as an error
+    # print "Could not find $DEB_PROVIDES - fetching and installing $DEB"
+    wget -q http://apt.puppetlabs.com/$DEB
+    dpkg -i $DEB
+
+    apt-get update
+    apt-get install byobu
+    apt-get install vim
+    apt-get install --yes puppet
+    gem install hiera-eyaml
+    echo '_byobu_sourced=1 . /usr/bin/byobu-launch' >> /home/vagrant/.profile
+fi


### PR DESCRIPTION
@Conzar wrote:

By setting the provider on the server worked for Ubuntu 12.04, 14.04,
and 15.04.  I was unable to get 10.04 working (there were some problems
outside the scope of this issue with the code that 10.04 has).

However, I ran into a new issue with 15.04.  The following bug report
best describes the problem:

https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+bug/1428961

Essentially, idmapd no longer as an init script and therefore fails. The
nfs-server init script manages idmapd so I used a case statement to
remove this functionality from Ubuntu 15.04 and later versions.

Finially, I added a vagrant directory that contains the testing
framework that I used to manually test all of the supported version
(10.04, 12.04, 14.04, and 15.04).  I had to modify the tests/init.pp to
test both the server and client.
