### PR TITLE
set 'nfslock' as the client service name on RHEL 7

### DIFF
--- a/manifests/client/redhat/service.pp
+++ b/manifests/client/redhat/service.pp
@@ -8,7 +8,6 @@ class nfs::client::redhat::service {
   service {'nfslock':
     ensure    => running,
     name      => $::nfs::client::redhat::params::osmajor ? {
-      7       => 'rpc-statd',
       default => 'nfslock'
     },
     enable    => $::nfs::client::redhat::params::osmajor ? {


### PR DESCRIPTION
... removing the special case that sets 'rpc-statd' there

I'm using this module on a host running CentOS 7 (`lsb_release -r` says "7.0.1406") and configuring an NFS server on it fails when the module tries to run the service `rpc-statd`. According to RedHat's docs, `nfslock` is what we want here. From https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-nfs.html:

> **nfslock**
> 
>    `systemctl start nfs-lock.service` activates a mandatory service that starts the appropriate RPC processes allowing NFS clients to lock files on the server.
