### PR TITLE
update redhat client parameters to recognize newer Amazon Linux releases

### DIFF
--- a/manifests/client/redhat/params.pp
+++ b/manifests/client/redhat/params.pp
@@ -13,13 +13,17 @@ class nfs::client::redhat::params {
     /^7\.\d+/: {
       $osmajor = 7
     }
-    # TODO: workaround for Fedora
-    /^\d{2,}/: {
-      $osmajor = 7
+    # Newer Amazon Linux releases use YYYY.MM (e.g. "2014.09" or "2015.03")
+    /^\d{4}\.\d{2}$/: {
+      $osmajor = 6
     }
     # Amazon linux operatingsystemrelease is verbose: 3.10.35-43.137.amzn1.x86_64
     /^[34]\.(\d|-|\.)+(amzn){1}/: {
       $osmajor = 6
+    }
+    # TODO: workaround for Fedora
+    /^\d{2,}/: {
+      $osmajor = 7
     }
     default:{
       fail("Operatingsystemrelease ${::operatingsystemrelease} not supported")


### PR DESCRIPTION
This change teaches the module to recognize newer releases of Amazon Linux, which use YYYY
.MM format for `$::operatingsystemrelease`, e.g. "2015.03" or "2014.09". Without this, the code in ` manifests/client/redhat/params.pp ` treats these versions of Amazon Linux as RHEL 7 because they match the `/^\d{2,}/` regex near the end of case statement.