### PR TITLE
Make sure rpcmountdopts has double quotes (on debian)

### DIFF
--- a/manifests/server/debian.pp
+++ b/manifests/server/debian.pp
@@ -18,7 +18,7 @@ class nfs::server::debian(
     file_line { 'rpc-mount-options':
       ensure => present,
       path   => '/etc/default/nfs-kernel-server',
-      line   => "RPCMOUNTDOPTS=--manage-gids --port ${mountd_port} --num-threads ${mountd_threads}",
+      line   => "RPCMOUNTDOPTS=\"--manage-gids --port ${mountd_port} --num-threads ${mountd_threads}\"",
       match  => '^#?RPCMOUNTDOPTS';
     }
 


### PR DESCRIPTION
Not working
```
:data1: ~$ grep RPCMOUNTDOPTS /etc/default/nfs-kernel-server
RPCMOUNTDOPTS=--manage-gids --port 2048 --num-threads 1
:data1: ~$ sudo /etc/init.d/nfs-kernel-server restart
/etc/default/nfs-kernel-server: line 12: --port: command not found
[ ok ] Restarting nfs-kernel-server (via systemctl): nfs-kernel-server.service.
:data1: ~$ apt-cache policy nfs-kernel-server | grep Installed 
  Installed: 1:1.2.8-9
```
Working
```
:data1: ~$ grep RPCMOUNTDOPTS /etc/default/nfs-kernel-server
RPCMOUNTDOPTS="--manage-gids --port 2048 --num-threads 1"
:data1: ~$ sudo /etc/init.d/nfs-kernel-server restart
[ ok ] Restarting nfs-kernel-server (via systemctl): nfs-kernel-server.service.
```