### PR TITLE
allow client mounts to be defined in Hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,20 @@ Mount root, where we  mount shares, default /srv
 Domain setting for idmapd, must be the same across server
 and clients. Default is to use $::domain fact.
 
+#####`mounts` (optional)
+
+If set, this attribute will be used to construct nfs::client::mount resources.
+You can use you ENC or hiera to provide the hash of nfs::client::mount
+resources definitions:
+
+```hiera
+nfs::client::mounts:
+  /mnt/test:
+    ensure: 'mounted'
+    server: '192.0.2.100'
+    share:  '/export/data'
+```
+
 #####Example
 
 ```puppet

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -31,7 +31,8 @@
 class nfs::client (
   $nfs_v4              = $::nfs::params::nfs_v4,
   $nfs_v4_mount_root   = $::nfs::params::nfs_v4_mount_root,
-  $nfs_v4_idmap_domain = $::nfs::params::nfs_v4_idmap_domain
+  $nfs_v4_idmap_domain = $::nfs::params::nfs_v4_idmap_domain,
+  $mounts              = undef
 ) inherits nfs::params {
 
   validate_bool($nfs_v4)
@@ -48,6 +49,10 @@ class nfs::client (
       nfs_v4              => $nfs_v4,
       nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
     }
+  }
+
+  if $mounts {
+    create_resources(nfs::client::mount, $mounts)
   }
 
 }


### PR DESCRIPTION
`nfs::server::exports` enables me to provide exports via Hiera, while there is no such feature for client mounts.

I reopened this PR against the develop branch, you can find the original PR here: #69

I updated the Readme as requested but I'm unable to find a simple way to test this change. In addition, there is no test for `nfs::server::exports`.