### PR TITLE
Allow setting up manual mount from client args

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -31,7 +31,8 @@
 class nfs::client (
   $nfs_v4              = $::nfs::params::nfs_v4,
   $nfs_v4_mount_root   = $::nfs::params::nfs_v4_mount_root,
-  $nfs_v4_idmap_domain = $::nfs::params::nfs_v4_idmap_domain
+  $nfs_v4_idmap_domain = $::nfs::params::nfs_v4_idmap_domain,
+  $mounts = undef,
 ) inherits nfs::params {
 
   validate_bool($nfs_v4)
@@ -48,6 +49,10 @@ class nfs::client (
       nfs_v4              => $nfs_v4,
       nfs_v4_idmap_domain => $nfs_v4_idmap_domain,
     }
+  }
+
+  if $mounts {
+    create_resources('nfs::client::mount', $mounts)
   }
 
 }

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -57,4 +57,12 @@ describe 'nfs::client' do
       }.to raise_error(Puppet::Error, /NFS client is not supported on Darwin/)
     end
   end
+  context "Mount manually set" do
+    let(:title) { '/srv/test' }
+    let(:facts) { { :operatingsystem => 'ubuntu', :clientcert => 'test.example.com' } }
+    let(:params) { mounts: { :server => 'nfs.int.net', :share => '/srv/share' } }
+    it do
+      should compile
+      should contain_class('nfs::client')
+  end
 end


### PR DESCRIPTION
This patch allows passing in a hash to setup mounts.  This is similar behavior to nfs::server::exports, but (a) it does not require the server's export to be managed by the same puppet (b) is just client side.