### PR TITLE
idmapd is only run on NFSv4 Ubuntu clients for versions < 16.04

### DIFF
--- a/manifests/client/ubuntu/service.pp
+++ b/manifests/client/ubuntu/service.pp
@@ -7,10 +7,12 @@ class nfs::client::ubuntu::service {
   }
 
   if $nfs::client::ubuntu::nfs_v4 {
-    service { 'idmapd':
-      ensure    => running,
-      enable    => true,
-      subscribe => Augeas['/etc/idmapd.conf', '/etc/default/nfs-common'],
+    if versioncmp($::lsbdistrelease, '16.04') < 0 {
+      service { 'idmapd':
+        ensure    => running,
+        enable    => true,
+        subscribe => Augeas['/etc/idmapd.conf', '/etc/default/nfs-common'],
+      }
     }
   } else {
     service { 'idmapd':


### PR DESCRIPTION
For details see comment #1 on
https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+bug/1557015