### PR TITLE
WIP: Bumped concat requirement, requires puppet 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,5 @@ matrix:
   include:
     - rvm: 2.1.9
       env: PUPPET_GEM_VERSION='~> 4.0' COVERAGE=yes
-    - rvm: 2.4.4
-      env: PUPPET_GEM_VERSION='~> 5.0' COVERAGE=yes
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script: bundle exec rake validate lint spec
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.1.6
+    - rvm: 2.1.9
       env: PUPPET_GEM_VERSION='~> 4.0' COVERAGE=yes STRICT_VARIABLES=yes
     - rvm: 2.4.4
       env: PUPPET_GEM_VERSION='~> 5.0' COVERAGE=yes STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION='~> 4.0' COVERAGE=yes STRICT_VARIABLES=yes
+      env: PUPPET_GEM_VERSION='~> 4.0' COVERAGE=yes
     - rvm: 2.4.4
-      env: PUPPET_GEM_VERSION='~> 5.0' COVERAGE=yes STRICT_VARIABLES=yes
+      env: PUPPET_GEM_VERSION='~> 5.0' COVERAGE=yes
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   include:
     - rvm: 2.1.6
       env: PUPPET_GEM_VERSION='~> 4.0' COVERAGE=yes STRICT_VARIABLES=yes
-    - rvm: 2.1.6
+    - rvm: 2.4.4
       env: PUPPET_GEM_VERSION='~> 5.0' COVERAGE=yes STRICT_VARIABLES=yes
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ matrix:
     - rvm: 2.1.6
       env: PUPPET_GEM_VERSION='~> 4.0' COVERAGE=yes STRICT_VARIABLES=yes
     - rvm: 2.1.6
-      env: PUPPET_GEM_VERSION='https://github.com/puppetlabs/puppet.git#stable
-    - rvm: 2.1.5
-      env: PUPPET_GEM_VERSION='~> 3.0' FUTURE_PARSER=yes
-    - rvm: 2.1.5
-      env: PUPPET_GEM_VERSION='~> 3.0'
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION='~> 3.0'
+      env: PUPPET_GEM_VERSION='~> 5.0' COVERAGE=yes STRICT_VARIABLES=yes
 notifications:
   email: false

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -44,10 +44,10 @@ class nfs::client (
 
   # ensure dependencies for mount
 
-  Class["::nfs::client::${::nfs::params::osfamily}::install"] ->
-  Class["::nfs::client::${::nfs::params::osfamily}::configure"] ->
-  Class["::nfs::client::${::nfs::params::osfamily}::service"] ->
-  Class['::nfs::client']
+  Class["::nfs::client::${::nfs::params::osfamily}::install"]
+  -> Class["::nfs::client::${::nfs::params::osfamily}::configure"]
+  -> Class["::nfs::client::${::nfs::params::osfamily}::service"]
+  -> Class['::nfs::client']
 
   if !defined( Class["nfs::client::${::nfs::params::osfamily}"]) {
     class{ "nfs::client::${::nfs::params::osfamily}":

--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -7,8 +7,8 @@ class nfs::client::debian (
   include ::nfs::client::debian::configure
   include ::nfs::client::debian::service
 
-  Class['::nfs::client::debian::install']->
-  Class['::nfs::client::debian::configure']->
-  Class['::nfs::client::debian::service']
+  Class['::nfs::client::debian::install']
+  -> Class['::nfs::client::debian::configure']
+  -> Class['::nfs::client::debian::service']
 
 }

--- a/manifests/client/gentoo.pp
+++ b/manifests/client/gentoo.pp
@@ -7,9 +7,9 @@ class nfs::client::gentoo (
   include ::nfs::client::gentoo::configure
   include ::nfs::client::gentoo::service
 
-  Class['::nfs::client::gentoo::install']->
-  Class['::nfs::client::gentoo::configure']->
-  Class['::nfs::client::gentoo::service']
+  Class['::nfs::client::gentoo::install']
+  -> Class['::nfs::client::gentoo::configure']
+  -> Class['::nfs::client::gentoo::service']
 
 
 }

--- a/manifests/client/redhat.pp
+++ b/manifests/client/redhat.pp
@@ -7,8 +7,8 @@ class nfs::client::redhat (
   include ::nfs::client::redhat::configure
   include ::nfs::client::redhat::service
 
-  Class['::nfs::client::redhat::install']->
-  Class['::nfs::client::redhat::configure']->
-  Class['::nfs::client::redhat::service']
+  Class['::nfs::client::redhat::install']
+  -> Class['::nfs::client::redhat::configure']
+  -> Class['::nfs::client::redhat::service']
 
 }

--- a/manifests/client/ubuntu.pp
+++ b/manifests/client/ubuntu.pp
@@ -7,8 +7,8 @@ class nfs::client::ubuntu (
   include ::nfs::client::ubuntu::configure
   include ::nfs::client::ubuntu::service
 
-  Class['::nfs::client::ubuntu::install']->
-  Class['::nfs::client::ubuntu::configure']->
-  Class['::nfs::client::ubuntu::service']
+  Class['::nfs::client::ubuntu::install']
+  -> Class['::nfs::client::ubuntu::configure']
+  -> Class['::nfs::client::ubuntu::service']
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
     }
   ],
   "name": "echocat-nfs",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "source": "https://github.com/echocat/puppet-nfs.git",
   "author": "echocat",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -52,12 +53,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.7.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=3.0.0 <5.0.0"
+      "version_requirement": ">=4.7.0 <5.0.0"
     }
   ],
   "name": "echocat-nfs",
@@ -70,6 +67,6 @@
   "issues_url": "https://github.com/echocat/puppet-nfs/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.8.0 < 5.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 3.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 3.0.0 <= 5.3.0"}
   ]
 }


### PR DESCRIPTION
This pull request is to check CI first. I saw that the concat upgrade was already tried some months ago, but the CI failed on things that were not related to the change itself.

Still, the concat module since version 3 requires puppet 4, and this seems to be a big bump to the current compatibility (still listed to support puppet3).