### PR TITLE
Do not start idmapd on NFSv4 clients running newer Debian releases

### DIFF
--- a/manifests/client/debian/service.pp
+++ b/manifests/client/debian/service.pp
@@ -6,7 +6,9 @@ class nfs::client::debian::service {
     hasstatus => false,
   }
 
-  if $nfs::client::debian::nfs_v4 {
+  # See https://bugs.debian.org/858274#10 why idmapd is not needed
+  # on NFSv4 clients running newer Debian releases
+  if $nfs::client::debian::nfs_v4 and versioncmp($facts['os']['release']['major'], '9') < 0 {
     service { 'idmapd':
       ensure    => running,
       enable    => true,


### PR DESCRIPTION
See https://bugs.debian.org/858274#10 for details. This PR is the Debian equivalent of #77.