### PR TITLE
feat: Updated concat dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -66,6 +66,6 @@
   "issues_url": "https://github.com/echocat/puppet-nfs/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.8.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 5.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 7.0.0"}
   ]
 }


### PR DESCRIPTION
This updates the concat dependency as we needed to migrate to a newer version. So far, nothing breaks.